### PR TITLE
Fixes Client-side stair spawn

### DIFF
--- a/Assets/Resources/Enemy.prefab
+++ b/Assets/Resources/Enemy.prefab
@@ -519,7 +519,7 @@ Transform:
   m_GameObject: {fileID: 6444308001262241288}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 64.37959, y: -1, z: -19.569904}
+  m_LocalPosition: {x: -22.417233, y: -1, z: 23.32518}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:

--- a/Assets/Resources/Pickups/HealthOrb.prefab
+++ b/Assets/Resources/Pickups/HealthOrb.prefab
@@ -34,7 +34,7 @@ Transform:
   m_GameObject: {fileID: 1950060490699823590}
   serializedVersion: 2
   m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 60.750065, y: -1.6, z: -15.874544}
+  m_LocalPosition: {x: -7.6175666, y: -1.6, z: 16.336102}
   m_LocalScale: {x: 0.25754, y: 0.25754, z: 0.25754}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Resources/Pickups/ManaOrb.prefab
+++ b/Assets/Resources/Pickups/ManaOrb.prefab
@@ -34,7 +34,7 @@ Transform:
   m_GameObject: {fileID: 1950060490699823590}
   serializedVersion: 2
   m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 61.865807, y: -1.6, z: -15.56223}
+  m_LocalPosition: {x: -0.19724375, y: -1.6, z: 16.257866}
   m_LocalScale: {x: 0.25754, y: 0.25754, z: 0.25754}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Resources/Projectiles/FireProjectile.prefab
+++ b/Assets/Resources/Projectiles/FireProjectile.prefab
@@ -34,7 +34,7 @@ Transform:
   m_GameObject: {fileID: 585884064168877562}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 58.44053, y: -0.4121458, z: -15.90831}
+  m_LocalPosition: {x: -6.1144166, y: -0.48020464, z: 26.188824}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Scripts/DungeonGeneration/Dungeon.cs
+++ b/Assets/Scripts/DungeonGeneration/Dungeon.cs
@@ -228,7 +228,6 @@ public class Dungeon : NetworkBehaviour
         }
     }
 
-    //[ServerRpc(RequireOwnership = false)]
     private void InitiateNewRoom(
         NetworkObjectReference currentRoomNOR,
         string prefabName,

--- a/Assets/Scripts/Interactables/DoorButton.cs
+++ b/Assets/Scripts/Interactables/DoorButton.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using Unity.Netcode;
 using UnityEngine;
 
 public class DoorButton : Interactable
@@ -15,7 +16,7 @@ public class DoorButton : Interactable
         {
             Player.LocalInstance.playerMana.IncrementPlayerMana(-manaCost);
             door.RemoveDoor();
-            door.dungeon.AddRandomRoom(door.room, door.direction, roomType);
+            door.dungeon.AddRandomRoomServerRpc(door.room.GetComponent<NetworkObject>(), door.direction, roomType);
         }
     }
 

--- a/Assets/Scripts/Objectives/PuzzleController.cs
+++ b/Assets/Scripts/Objectives/PuzzleController.cs
@@ -55,7 +55,8 @@ public class PuzzleController : NetworkBehaviour
             if (solution.SequenceEqual(playerInput))
             {
                 CompletePuzzleClientRpc();
-                ObjectiveController.Instance.ProgressObjective();
+                if(ObjectiveController.Instance.objectiveSelected.Value == ObjectiveController.ObjectiveType.Puzzle)
+                    ObjectiveController.Instance.ProgressObjective();
             }
         }
     }


### PR DESCRIPTION
Moves more dungeon generation logic to server. This avoids client running the second stair piece generation prior to the completion of the client RPC that updates the reference to the other stair piece.

Cheekily also fixes a bug where the puzzle completion would progress any objective